### PR TITLE
adding CNAME file to build output for custom docs domain

### DIFF
--- a/.github/workflows/sphinx-deploy.yml
+++ b/.github/workflows/sphinx-deploy.yml
@@ -29,6 +29,9 @@ jobs:
         run: |
           sphinx-build -W -b html docs/ build
 
+      - name: Create CNAME file
+        run: echo "docs.granitecode.ai" > build/CNAME
+
       - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Configures the custom domain `docs.granitecode.ai` for our documentation site.

This PR adds `CNAME` file to the build artifact via the workflow, allowing GitHub Pages to serve the documentation from the new, shorter URL.
