### PR TITLE
add a link to the official granite website from the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # Granite.Code
 
-Granite.Code is an coding assistant for VS Code. It makes use of the [Granite family of AI models](https://www.ibm.com/granite) to provide a high quality AI assistant experience, while providing full control over privacy and information sharing. To achieve this, Granite.Code downloads and runs Granite models locally, so that no data is shared with other parties.
+[Granite.Code](https://granitecode.ai/) is an coding assistant for VS Code. It makes use of the [Granite family of AI models](https://www.ibm.com/granite) to provide a high quality AI assistant experience, while providing full control over privacy and information sharing. To achieve this, Granite.Code downloads and runs Granite models locally, so that no data is shared with other parties.
 
 Granite.Code can be installed as a VS Code extension: See [setup](https://docs.granitecode.github.io/setup) to get started.
 


### PR DESCRIPTION
linking the granitecode.ai website to the documentation.