### PR TITLE
updated the navigation links after domain change

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -2,7 +2,7 @@
 
 This page provides information on how to get the most out of Granite.Code. It covers best practices for getting accurate and helpful chat responses, as well as supplementary options which make Granite.Code's features even more powerful.
 
-Before you read this guide, you should be familiar with the main Granite.Code features, which are described in the [getting started tutorial](https://docs.granitecode.github.io/getting-started).
+Before you read this guide, you should be familiar with the main Granite.Code features, which are described in the [getting started tutorial](getting-started).
 
 ## Asking effective questions
 
@@ -53,7 +53,7 @@ For more information on the docs context provider, see the [Continue documentati
 
 ## Making different types of edits
 
-Granite.Code's edit feature was introduced in the [getting started tutorial](https://docs.granitecode.github.io/getting-started), where we saw how code can be easily made more readable. There are many other types of changes that can be made with Granite.Code. Some of these are available in the Granite.Code context menu in the code editor. This includes actions to:
+Granite.Code's edit feature was introduced in the [getting started tutorial](getting-started), where we saw how code can be easily made more readable. There are many other types of changes that can be made with Granite.Code. Some of these are available in the Granite.Code context menu in the code editor. This includes actions to:
 
 * Fix grammar and spelling mistakes
 * Fix code errors

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,4 +95,4 @@ Let's use autocompletion to write assertions for the sorting algorithms from the
 
 ## Next steps
 
-This guide has introduced some essential Granite.Code features. However, there is much more to Granite.Code, including techniques which will allow you to get the most out of the features that have just been introduced. When you're ready, head over to the [best practices guide](https://docs.granitecode.github.io/best-practices) to learn more.
+This guide has introduced some essential Granite.Code features. However, there is much more to Granite.Code, including techniques which will allow you to get the most out of the features that have just been introduced. When you're ready, head over to the [best practices guide](best-practices) to learn more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 [Granite.Code](https://granitecode.ai/) is an coding assistant for VS Code. It makes use of the [Granite family of AI models](https://www.ibm.com/granite) to provide a high quality AI assistant experience, while providing full control over privacy and information sharing. To achieve this, Granite.Code downloads and runs Granite models locally, so that no data is shared with other parties.
 
-Granite.Code can be installed as a VS Code extension: See [setup](https://docs.granitecode.github.io/setup) to get started.
+Granite.Code can be installed as a VS Code extension: See [setup](setup) to get started.
 
 ## Get in Touch
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@ Once you have installed Granite.Code, it is necessary to get the latest Granite 
 
 If you need to restart the setup wizard for any reason, it can be launched from the VS Code command palette using the `Granite.Code: Setup Granite as code assistant` command.
 
-Once you have set up Granite.Code, we recommend that you try out the [getting started tutorial](https://docs.granitecode.github.io/getting-started).
+Once you have set up Granite.Code, we recommend that you try out the [getting started tutorial](getting-started).
 
 ## System requirements
 


### PR DESCRIPTION
fixed navigation links after domain change from
docs.granitecode.github.io to relative links after switching to docs.granitecode.ai domain.